### PR TITLE
[Feat] Extension new comments core

### DIFF
--- a/addNewComment.js
+++ b/addNewComment.js
@@ -141,7 +141,7 @@ function handleSubmit(event) {
   event.preventDefault();
 
   const textareaElement = event.target.querySelector("textarea");
-  const selectValue = event.target.querySelector("select");
+  const allowPublic = event.target.querySelector("select");
   const emailElements = event.target.querySelectorAll("input[name='email']");
   const recipientEmail = Array.from(emailElements).map(
     (emailInput) => emailInput.value,
@@ -156,12 +156,12 @@ function handleSubmit(event) {
     y,
   };
 
-  let allowPublic;
+  let selectValue;
 
-  if (selectValue.value === "공개") {
-    allowPublic = true;
+  if (allowPublic.value === "공개") {
+    selectValue = true;
   } else {
-    allowPublic = false;
+    selectValue = false;
   }
 
   if (textareaElement.value.length > 200) {
@@ -177,7 +177,7 @@ function handleSubmit(event) {
       action: "submitForm",
       data: {
         inputValue: textareaElement.value,
-        selectValue: allowPublic,
+        allowPublic: selectValue,
         recipientEmail,
         postCoordinate,
         nowDate,

--- a/addNewComment.js
+++ b/addNewComment.js
@@ -72,21 +72,10 @@ function openModal(x, y) {
 
   const modal = document.createElement("form");
   modal.setAttribute("name", "comment");
+  modal.addEventListener("submit", handleSubmit);
 
   const textarea = document.createElement("textarea");
   const emailInput = document.createElement("input");
-  const friendsDropdown = document.createElement("select");
-
-  textarea.addEventListener("input", function (event) {
-    const inputValue = event.target.value;
-
-    if (inputValue.includes("@")) {
-      friendsDropdown.style.display = "block";
-    } else {
-      friendsDropdown.style.display = "none";
-    }
-  });
-
   const allowPublic = document.createElement("select");
 
   const option1 = document.createElement("option");
@@ -146,6 +135,55 @@ function openModal(x, y) {
   modal.focus();
 
   return modal;
+}
+
+function handleSubmit(event) {
+  event.preventDefault();
+
+  const textareaElement = event.target.querySelector("textarea");
+  const selectValue = event.target.querySelector("select");
+  const emailElements = event.target.querySelectorAll("input[name='email']");
+  const recipientEmail = Array.from(emailElements).map(
+    (emailInput) => emailInput.value,
+  );
+
+  const formElement = document.getElementsByClassName("newComment");
+  const x = formElement[0].style.left;
+  const y = formElement[0].style.top;
+
+  const postCoordinate = {
+    x,
+    y,
+  };
+
+  let allowPublic;
+
+  if (selectValue.value === "공개") {
+    allowPublic = true;
+  } else {
+    allowPublic = false;
+  }
+
+  const nowDate = new Date();
+
+  chrome.runtime.sendMessage(
+    {
+      action: "submitForm",
+      data: {
+        inputValue: textareaElement.value,
+        selectValue: allowPublic,
+        recipientEmail,
+        postCoordinate,
+        nowDate,
+      },
+    },
+    function (response) {
+      console.log(response);
+    },
+  );
+
+  document.removeEventListener("mousemove", handleMouseMove);
+  removeElementsByClass("newComment");
 }
 
 document.addEventListener(

--- a/addNewComment.js
+++ b/addNewComment.js
@@ -164,6 +164,12 @@ function handleSubmit(event) {
     allowPublic = false;
   }
 
+  if (textareaElement.value.length > 200) {
+    return alert("200자 이하로 작성해주세요!");
+  } else if (textareaElement.value.length < 1) {
+    return alert("1글자 이상 작성해주세요!");
+  }
+
   const nowDate = new Date();
 
   chrome.runtime.sendMessage(

--- a/service_worker.js
+++ b/service_worker.js
@@ -13,6 +13,17 @@ chrome.runtime.onMessage.addListener(async (message, sender, sendResponse) => {
     });
   } else if (message.action === "submitForm") {
     try {
+      const screenshot = await new Promise((resolve) => {
+        chrome.tabs.captureVisibleTab(
+          { format: "png", quality: 90 },
+          (imageUrl) => {
+            resolve(imageUrl);
+          },
+        );
+      });
+
+      const encodeScreenshot = btoa(screenshot);
+
       const { currentUrl, userData } = await new Promise((resolve) => {
         chrome.storage.local.get(["currentUrl", "userData"], (result) => {
           resolve(result);
@@ -25,6 +36,7 @@ chrome.runtime.onMessage.addListener(async (message, sender, sendResponse) => {
         postDate: message.data.nowDate,
         postUrl: currentUrl,
         postCoordinate: message.data.postCoordinate,
+        screenshot: encodeScreenshot,
         allowPublic: message.data.selectValue,
         publicUsers: [],
         recipientEmail: message.data.recipientEmail,

--- a/service_worker.js
+++ b/service_worker.js
@@ -1,10 +1,52 @@
-chrome.runtime.onMessage.addListener((message) => {
+chrome.runtime.onMessage.addListener(async (message, sender, sendResponse) => {
   if (message.action === "openWebPage") {
     chrome.tabs.create({ url: `localhost:5173?token=${message.token}` });
   } else if (message.action === "addNewComment") {
+    const currentUrl = message.currentUrl;
+    const userData = message.userData;
+
+    chrome.storage.local.set({ currentUrl, userData });
+
     chrome.scripting.executeScript({
       target: { tabId: message.tabId },
       files: ["addNewComment.js"],
     });
+  } else if (message.action === "submitForm") {
+    try {
+      const { currentUrl, userData } = await new Promise((resolve) => {
+        chrome.storage.local.get(["currentUrl", "userData"], (result) => {
+          resolve(result);
+        });
+      });
+
+      const newComment = {
+        userData,
+        text: message.data.inputValue,
+        postDate: message.data.nowDate,
+        postUrl: currentUrl,
+        postCoordinate: message.data.postCoordinate,
+        allowPublic: message.data.selectValue,
+        publicUsers: [],
+        recipientEmail: message.data.recipientEmail,
+      };
+
+      const response = await fetch("http://localhost:3000/comments/new", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(newComment),
+      });
+
+      if (response.ok) {
+        console.log("새로운 글 등록이 완료되었습니다");
+      } else {
+        console.error("some problem with Fetch");
+      }
+    } catch (error) {
+      console.error("An error:", error);
+    }
+
+    sendResponse("addNewComment로 부터 메시지를 받았습니다");
   }
 });

--- a/service_worker.js
+++ b/service_worker.js
@@ -1,64 +1,76 @@
-chrome.runtime.onMessage.addListener(async (message, sender, sendResponse) => {
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.action === "openWebPage") {
-    chrome.tabs.create({ url: `localhost:5173?token=${message.token}` });
+    handleOpenWebPage(message);
   } else if (message.action === "addNewComment") {
-    const currentUrl = message.currentUrl;
-    const userData = message.userData;
-
-    chrome.storage.local.set({ currentUrl, userData });
-
-    chrome.scripting.executeScript({
-      target: { tabId: message.tabId },
-      files: ["addNewComment.js"],
-    });
+    handleAddNewComment(message);
   } else if (message.action === "submitForm") {
-    try {
-      const screenshot = await new Promise((resolve) => {
-        chrome.tabs.captureVisibleTab(
-          { format: "png", quality: 90 },
-          (imageUrl) => {
-            resolve(imageUrl);
-          },
-        );
-      });
-
-      const encodeScreenshot = btoa(screenshot);
-
-      const { currentUrl, userData } = await new Promise((resolve) => {
-        chrome.storage.local.get(["currentUrl", "userData"], (result) => {
-          resolve(result);
-        });
-      });
-
-      const newComment = {
-        userData,
-        text: message.data.inputValue,
-        postDate: message.data.nowDate,
-        postUrl: currentUrl,
-        postCoordinate: message.data.postCoordinate,
-        screenshot: encodeScreenshot,
-        allowPublic: message.data.selectValue,
-        publicUsers: [],
-        recipientEmail: message.data.recipientEmail,
-      };
-
-      const response = await fetch("http://localhost:3000/comments/new", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(newComment),
-      });
-
-      if (response.ok) {
-        console.log("새로운 글 등록이 완료되었습니다");
-      } else {
-        console.error("some problem with Fetch");
-      }
-    } catch (error) {
-      console.error("An error:", error);
-    }
-
-    sendResponse("addNewComment로 부터 메시지를 받았습니다");
+    handleSubmitForm(message, sendResponse);
   }
 });
+
+async function handleOpenWebPage(message) {
+  await chrome.tabs.create({ url: `localhost:5173?token=${message.token}` });
+}
+
+async function handleAddNewComment(message) {
+  const currentUrl = message.currentUrl;
+  const userData = message.userData;
+
+  await chrome.storage.local.set({ currentUrl, userData });
+
+  chrome.scripting.executeScript({
+    target: { tabId: message.tabId },
+    files: ["addNewComment.js"],
+  });
+}
+
+async function handleSubmitForm(message, sendResponse) {
+  try {
+    const screenshot = await new Promise((resolve) => {
+      chrome.tabs.captureVisibleTab(
+        { format: "png", quality: 90 },
+        (imageUrl) => {
+          resolve(imageUrl);
+        },
+      );
+    });
+
+    const encodeScreenshot = btoa(screenshot);
+
+    const { currentUrl, userData } = await new Promise((resolve) => {
+      chrome.storage.local.get(["currentUrl", "userData"], (result) => {
+        resolve(result);
+      });
+    });
+
+    const newComment = {
+      userData,
+      text: message.data.inputValue,
+      postDate: message.data.nowDate,
+      postUrl: currentUrl,
+      postCoordinate: message.data.postCoordinate,
+      screenshot: encodeScreenshot,
+      allowPublic: message.data.allowPublic,
+      publicUsers: [],
+      recipientEmail: message.data.recipientEmail,
+    };
+
+    const response = await fetch("http://localhost:3000/comments/new", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(newComment),
+    });
+
+    if (response.ok) {
+      console.log("Fetch complited");
+    } else {
+      console.error("some problem with Fetch");
+    }
+  } catch (error) {
+    console.error("An error:", error);
+  }
+
+  sendResponse("addNewComment has been arrived");
+}

--- a/src/components/Header/NewComment/index.jsx
+++ b/src/components/Header/NewComment/index.jsx
@@ -1,12 +1,19 @@
+import useUserStore from "../../../store/userProfile";
+
 function NewComment() {
+  const { userData } = useUserStore();
+
   const handleOnClick = () => {
     chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
       const activeTab = tabs[0];
       const tabId = activeTab.id;
+      const currentUrl = activeTab.url;
 
       chrome.runtime.sendMessage({
         action: "addNewComment",
         tabId,
+        currentUrl,
+        userData,
       });
     });
   };


### PR DESCRIPTION
### itsComments

## [Comment입력 코어 기능](https://boom-plant-4c9.notion.site/CE-Comment-2eb27aae24bb444196c02fb20cf4c25f)

## Todo

- [x]  Comment의 제한 글자수는 제한 (1~200자)
- [x]  전송 버튼 클릭 시 스크린샷 촬영
- [x]  전송 버튼 클릭시 백엔드로 작성한 comment 전달

## Description

- 작업 내용
1. addComment함수를 리팩토링했습니다:
   - `removeElementsByClass`, `createCustomCursor`, `setModalStyle`, `handleMouseMove`, `openModal`, 및 `handleSubmit` 함수를 정리하였습니다.

2. 'openModal' 함수를 업데이트하여 폼 제출에 대한 'handleSubmit' 이벤트 리스너를 포함시켰습니다.

3. 'NewComment' 컴포넌트에서 클릭 이벤트를 처리하고 백그라운드 스크립트에 필요한 데이터를 메시지로 보내었습니다.

4. 'addNumComment'에서 백그라운드 스크립트에 `comment`를 전달하게 되면 해당 페이지에 스크린샷을 찍고 backend에 데이터를 보냅니다.

## Concern(필요시)

- 리뷰 요청 부분 & 컨펌 필요 부분

## PR 전 확인사항

- [x] 가장 최신 브랜치를 pull
- [x] 브랜치명 확인하기
- [x] 코드 컨벤션을 모두 지키기
- [x] reviewer, assignee 확인하기
- [x] conflict가 모두 해결됐는지 확인하기

### 이미지(필요시)
