### PR TITLE
[Feat] fetch and display page comments on page navigation 

### DIFF
--- a/displayComments.js
+++ b/displayComments.js
@@ -1,0 +1,4 @@
+chrome.runtime.sendMessage({
+  action: "pageUrlUpdated",
+  url: window.location.href,
+});

--- a/displayComments.js
+++ b/displayComments.js
@@ -2,3 +2,60 @@ chrome.runtime.sendMessage({
   action: "pageUrlUpdated",
   url: window.location.href,
 });
+
+chrome.runtime.onMessage.addListener((message) => {
+  if (message.action === "sendDataToDisplayComments") {
+    const receivedData = message.data;
+
+    for (const commentData of receivedData) {
+      displayCommentModal(commentData);
+    }
+  }
+});
+
+function displayCommentModal(commentData) {
+  const modal = document.createElement("div");
+  modal.classList.add("modal");
+
+  const closeButton = document.createElement("span");
+  closeButton.innerText = "✖";
+  closeButton.style.float = "right";
+  closeButton.style.cursor = "pointer";
+  closeButton.addEventListener("click", () => {
+    modal.remove();
+  });
+  modal.appendChild(closeButton);
+
+  const creatorNickname = document.createElement("div");
+  creatorNickname.innerText = commentData.creator.nickname;
+  creatorNickname.style.borderBottom = "1px solid #ccc";
+  creatorNickname.style.marginLeft = "10px";
+  modal.appendChild(creatorNickname);
+  console.log(commentData.creator.nickname);
+
+  const textContent = document.createElement("div");
+  textContent.innerText = commentData.text;
+  textContent.style.borderBottom = "1px solid #ccc";
+  textContent.style.marginLeft = "10px";
+  textContent.style.maxHeight = "auto";
+  textContent.style.overflow = "auto";
+  modal.appendChild(textContent);
+
+  const nextPageLink = document.createElement("a");
+  nextPageLink.innerText = "댓글로 이동";
+  nextPageLink.href = "https://www.daum.net";
+  nextPageLink.style.display = "block";
+  nextPageLink.style.marginTop = "10px";
+  nextPageLink.style.marginLeft = "10px";
+  modal.appendChild(nextPageLink);
+
+  modal.style.position = "absolute";
+  modal.style.left = `${commentData.postCoordinate.x}`;
+  modal.style.top = `${commentData.postCoordinate.y}`;
+  modal.style.width = "300px";
+  modal.style.background = "white";
+  modal.style.border = "1px solid black";
+  modal.style.borderRadius = "10px";
+
+  document.body.appendChild(modal);
+}

--- a/displayComments.js
+++ b/displayComments.js
@@ -14,6 +14,7 @@ chrome.runtime.onMessage.addListener((message) => {
 });
 
 function displayCommentModal(commentData) {
+  const shadow = document.createElement("div").attachShadow({ mode: "open" });
   const modal = document.createElement("div");
   modal.classList.add("modal");
 
@@ -31,7 +32,6 @@ function displayCommentModal(commentData) {
   creatorNickname.style.borderBottom = "1px solid #ccc";
   creatorNickname.style.marginLeft = "10px";
   modal.appendChild(creatorNickname);
-  console.log(commentData.creator.nickname);
 
   const textContent = document.createElement("div");
   textContent.innerText = commentData.text;
@@ -57,5 +57,7 @@ function displayCommentModal(commentData) {
   modal.style.border = "1px solid black";
   modal.style.borderRadius = "10px";
 
-  document.body.appendChild(modal);
+  shadow.appendChild(modal);
+
+  document.body.appendChild(shadow);
 }

--- a/service_worker.js
+++ b/service_worker.js
@@ -13,7 +13,9 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 });
 
 async function handleUpdateLoginUser(message) {
-  chrome.runtime.loginUser = message.user;
+  const loginUser = message.user;
+
+  await chrome.storage.local.set({ loginUser });
 }
 
 async function handleOpenWebPage(message) {
@@ -106,8 +108,12 @@ async function sendUserDataToServer(userId, pageUrl) {
 
 async function handlePageUrlUpdated(message) {
   try {
-    const userId = chrome.runtime.loginUser;
     const pageUrl = message.url;
+    const userId = await new Promise((resolve) => {
+      chrome.storage.local.get(["loginUser"], (result) => {
+        resolve(result.loginUser);
+      });
+    });
 
     const responseData = await sendUserDataToServer(userId, pageUrl);
 

--- a/service_worker.js
+++ b/service_worker.js
@@ -104,5 +104,22 @@ function handlePageUrlUpdated(message) {
   const userId = chrome.runtime.loginUser;
   const pageUrl = message.url;
 
-  sendUserDataToServer(userId, pageUrl);
+  sendUserDataToServer(userId, pageUrl)
+    .then((responseData) => {
+      const responseComments = responseData.pageComments;
+      chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
+        const activeTab = tabs[0];
+        const message = {
+          action: "sendDataToDisplayComments",
+          data: responseComments,
+        };
+
+        chrome.tabs.sendMessage(activeTab.id, message, (response) => {
+          console.log("Response from content script:", response);
+        });
+      });
+    })
+    .catch((error) => {
+      console.error("Error occurred during data transmission:", error);
+    });
 }

--- a/service_worker.js
+++ b/service_worker.js
@@ -5,6 +5,10 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     handleAddNewComment(message);
   } else if (message.action === "submitForm") {
     handleSubmitForm(message, sendResponse);
+  } else if (message.action === "pageUrlUpdated") {
+    handlePageUrlUpdated(message, sendResponse);
+  } else if (message.action === "updateLoginUser") {
+    chrome.runtime.loginUser = message.user;
   }
 });
 
@@ -73,4 +77,32 @@ async function handleSubmitForm(message, sendResponse) {
   }
 
   sendResponse("addNewComment has been arrived");
+}
+
+async function sendUserDataToServer(userId, pageUrl) {
+  const serverEndpoint = `http://localhost:3000/location?userId=${encodeURIComponent(userId)}&pageUrl=${encodeURIComponent(pageUrl)}`;
+
+  return fetch(serverEndpoint, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+  })
+    .then((response) => response.json())
+    .then((responseData) => {
+      return responseData;
+    })
+    .catch((error) => {
+      console.error(
+        "Error occurred during data transmission to the server:",
+        error,
+      );
+    });
+}
+
+function handlePageUrlUpdated(message) {
+  const userId = chrome.runtime.loginUser;
+  const pageUrl = message.url;
+
+  sendUserDataToServer(userId, pageUrl);
 }

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -26,6 +26,11 @@ function App() {
 
           setAuthToken(authToken);
           setUserData(res.data.user);
+
+          chrome.runtime.sendMessage({
+            action: "updateLoginUser",
+            user: res.data.user._id,
+          });
         } catch (error) {
           console.log("Login error:", error);
         }

--- a/vite.config.js
+++ b/vite.config.js
@@ -11,6 +11,7 @@ export default defineConfig({
         "./manifest.json",
         "./service_worker.js",
         "./addNewComment.js",
+        "./displayComments.js",
       ],
     }),
   ],


### PR DESCRIPTION
### itsComments

## [웹페이지 이동시 해당 페이지 댓글표시](https://boom-plant-4c9.notion.site/CE-37c9e6af46b24d24bf0ec0b35d210ede?pvs=4)

## Todo

- [x]  페이지 이동시 content.js에서 백그라운드로 url전달
- [x]  백그라운드에서 sendGetRequest로 url 조회
- [x]  익스텐션 팝업에서 유저정보 백그라운드로 전달
- [x]  백그라운드에서 /location으로 get요청
- [x]  req.query.pageUrl로 url 정보 , req.query.user로 user 정보 전달
- [x]  응답받은 배열을 순회하면서 해당 좌표에 해당 comment 모달로 생성
- [x]  모달은 작성자닉네임, 댓글텍스트, 댓글경로이동 표시
- [x]  우측 상단에 댓글 종료 버튼 추가

## Description

- 팝업 로그인시 백그라운드에 로그인 유저 정보 전달 및 저장
- 페이지 이동시 displayComments.js에서 백그라운드로 해당 url주소 전달
- 유저id, 페이지 링크를 추가하여 /locaion으로 get api요청 전달
- 응답으로 받은 comments배열을 displayComments.js로 전달
- 해당 배열을 순회하면서 모달을 생성

## Concern(필요시)

## PR 전 확인사항

- [x] 가장 최신 브랜치를 pull
- [x] 브랜치명 확인하기
- [x] 코드 컨벤션을 모두 지키기
- [x] reviewer, assignee 확인하기
- [x] conflict가 모두 해결됐는지 확인하기

### 이미지(필요시)

