### PR TITLE
[Feat] Refactor data transmission to use FormData for image delivery

### DIFF
--- a/service_worker.js
+++ b/service_worker.js
@@ -58,8 +58,9 @@ async function handleSubmitForm(message, sendResponse) {
       );
     });
 
-    const blob = await fetch(imageDataUrl).then((res) => res.blob());
-    const screenshot = new File([blob], "screenshot.png", {
+    const imageResponse = await fetch(imageDataUrl);
+    const imageBlob = await imageResponse.blob();
+    const screenshot = new File([imageBlob], "screenshot.png", {
       type: "image/png",
     });
 

--- a/service_worker.js
+++ b/service_worker.js
@@ -49,7 +49,7 @@ async function handleAddNewComment(message) {
 
 async function handleSubmitForm(message, sendResponse) {
   try {
-    const screenshot = await new Promise((resolve) => {
+    const imageDataUrl = await new Promise((resolve) => {
       chrome.tabs.captureVisibleTab(
         { format: "png", quality: 90 },
         (imageUrl) => {
@@ -58,7 +58,10 @@ async function handleSubmitForm(message, sendResponse) {
       );
     });
 
-    const encodeScreenshot = btoa(screenshot);
+    const blob = await fetch(imageDataUrl).then((res) => res.blob());
+    const screenshot = new File([blob], "screenshot.png", {
+      type: "image/png",
+    });
 
     const { currentUrl, userData } = await new Promise((resolve) => {
       chrome.storage.local.get(["currentUrl", "userData"], (result) => {
@@ -66,24 +69,23 @@ async function handleSubmitForm(message, sendResponse) {
       });
     });
 
-    const newComment = {
-      userData,
-      text: message.data.inputValue,
-      postDate: message.data.nowDate,
-      postUrl: currentUrl,
-      postCoordinate: message.data.postCoordinate,
-      screenshot: encodeScreenshot,
-      allowPublic: message.data.allowPublic,
-      publicUsers: message.data.publicUsers,
-      recipientEmail: message.data.recipientEmail,
-    };
+    const formData = new FormData();
+    formData.append("userData", userData.email);
+    formData.append("text", message.data.inputValue);
+    formData.append("postDate", message.data.nowDate);
+    formData.append("postUrl", currentUrl);
+    formData.append(
+      "postCoordinate",
+      JSON.stringify(message.data.postCoordinate),
+    );
+    formData.append("allowPublic", message.data.allowPublic);
+    formData.append("publicUsers", JSON.stringify(message.data.publicUsers));
+    formData.append("recipientEmail", message.data.recipientEmail);
+    formData.append("screenshot", screenshot);
 
     const response = await fetch("http://localhost:3000/comments/new", {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(newComment),
+      body: formData,
     });
 
     if (response.ok) {
@@ -131,6 +133,7 @@ async function handlePageUrlUpdated(message) {
     const responseData = await sendUserDataToServer(userId, pageUrl);
 
     const responseComments = responseData.pageComments;
+    console.log(responseComments);
 
     chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
       const activeTab = tabs[0];


### PR DESCRIPTION
### itsComments

## S3전환으로 인한 추가작업

## Todo

## Description

- s3에 이미지 파일을 저장해야하기 때문에 기존의 스크린샷 이미지url을 blob 메서드를 이용하여 이미지 데이터를 블롭 객체로 변환
- File 생성자를 통해 화면 캡처를 나타내는 PNG 파일을 생성
- 텍스트 데이터만을 전송하는 기존 코드에서 파일을 함께 전송할수있는 multipart/form-data 형식으로 요청 변경
- 서버 미들웨어에서 "screenshot"의 name을 가진 요소를 전달하기때문에 스크린샷 파일에 name "screenshot"으로 지정

## Concern(필요시)

- 이미지 파일을 전달하여 s3에 저장하기위해 요청형식을 formData형식으로 변경하였습니다.

## PR 전 확인사항

- [x] 가장 최신 브랜치를 pull
- [x] 브랜치명 확인하기
- [x] 코드 컨벤션을 모두 지키기
- [x] reviewer, assignee 확인하기
- [x] conflict가 모두 해결됐는지 확인하기

### 이미지(필요시)
