### PR TITLE
[Refactor] Separate CSS Files and Transform Comment Display to Icon-Click Format

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -8,7 +8,12 @@ module.exports = {
     "plugin:react-hooks/recommended",
     "prettier",
   ],
-  ignorePatterns: ["dist", ".eslintrc.cjs", "/src/index.css"],
+  ignorePatterns: [
+    "dist",
+    ".eslintrc.cjs",
+    "/src/index.css",
+    "/styles/displayComments.css",
+  ],
   parserOptions: { ecmaVersion: "latest", sourceType: "module" },
   settings: { react: { version: "18.2" } },
   plugins: ["react-refresh"],

--- a/displayComments.js
+++ b/displayComments.js
@@ -1,3 +1,9 @@
+const styleSheet = document.createElement("link");
+styleSheet.rel = "stylesheet";
+styleSheet.type = "text/css";
+styleSheet.href = "styles/displayComments.css";
+document.head.appendChild(styleSheet);
+
 chrome.runtime.sendMessage({
   action: "pageUrlUpdated",
   url: window.location.href,
@@ -20,8 +26,6 @@ function displayCommentModal(commentData) {
 
   const closeButton = document.createElement("span");
   closeButton.innerText = "✖";
-  closeButton.style.float = "right";
-  closeButton.style.cursor = "pointer";
   closeButton.addEventListener("click", () => {
     modal.remove();
   });

--- a/displayComments.js
+++ b/displayComments.js
@@ -21,47 +21,62 @@ chrome.runtime.onMessage.addListener((message) => {
 
 function displayCommentModal(commentData) {
   const shadow = document.createElement("div").attachShadow({ mode: "open" });
+
+  const icon = document.createElement("img");
+  icon.src = `${commentData.creator.icon}`;
+  icon.classList.add("icon");
+
+  icon.style.left = `${commentData.postCoordinate.x}`;
+  icon.style.top = `${commentData.postCoordinate.y}`;
+
+  shadow.appendChild(icon);
+
+  const modal = createModal(commentData);
+  shadow.appendChild(modal);
+
+  icon.addEventListener("click", () => {
+    if (modal.style.display === "none" || modal.style.display === "") {
+      modal.style.display = "block";
+    } else {
+      modal.style.display = "none";
+    }
+  });
+
+  document.body.appendChild(shadow);
+}
+
+function createModal(commentData) {
   const modal = document.createElement("div");
   modal.classList.add("modal");
 
   const closeButton = document.createElement("span");
   closeButton.innerText = "✖";
   closeButton.addEventListener("click", () => {
-    modal.remove();
+    modal.style.display = "none";
   });
   modal.appendChild(closeButton);
 
   const creatorNickname = document.createElement("div");
   creatorNickname.innerText = commentData.creator.nickname;
-  creatorNickname.style.borderBottom = "1px solid #ccc";
-  creatorNickname.style.marginLeft = "10px";
   modal.appendChild(creatorNickname);
 
   const textContent = document.createElement("div");
   textContent.innerText = commentData.text;
-  textContent.style.borderBottom = "1px solid #ccc";
-  textContent.style.marginLeft = "10px";
-  textContent.style.maxHeight = "auto";
-  textContent.style.overflow = "auto";
   modal.appendChild(textContent);
 
   const nextPageLink = document.createElement("a");
   nextPageLink.innerText = "댓글로 이동";
   nextPageLink.href = `http://localhost:5173/comments/${commentData._id}`;
-  nextPageLink.style.display = "block";
-  nextPageLink.style.marginTop = "10px";
-  nextPageLink.style.marginLeft = "10px";
   modal.appendChild(nextPageLink);
 
-  modal.style.position = "absolute";
-  modal.style.left = `${commentData.postCoordinate.x}`;
-  modal.style.top = `${commentData.postCoordinate.y}`;
-  modal.style.width = "300px";
-  modal.style.background = "white";
-  modal.style.border = "1px solid black";
-  modal.style.borderRadius = "10px";
+  const offsetX = 20;
+  const offsetY = 20;
 
-  shadow.appendChild(modal);
+  const currentX = parseInt(commentData.postCoordinate.x, 10);
+  const currentY = parseInt(commentData.postCoordinate.y, 10);
 
-  document.body.appendChild(shadow);
+  modal.style.left = `${currentX + offsetX}px`;
+  modal.style.top = `${currentY + offsetY}px`;
+
+  return modal;
 }

--- a/styles/displayComments.css
+++ b/styles/displayComments.css
@@ -1,9 +1,17 @@
+.icon {
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  position: absolute;
+}
+
 .modal {
   position: absolute;
   width: 300px;
   background: rgba(0, 0, 0, 0.8);
   border: 1px solid #38d431;
   border-radius: 10px;
+  display: none;
 }
 
 .modal span {
@@ -24,7 +32,8 @@
 
 .modal a {
   display: block;
-  margin-top: 10px;
+  margin-top: 5px;
+  margin-bottom: 5px;
   margin-left: 10px;
   color: #38d431;
 }

--- a/styles/displayComments.css
+++ b/styles/displayComments.css
@@ -1,19 +1,21 @@
 .modal {
   position: absolute;
   width: 300px;
-  background: white;
-  border: 1px solid black;
+  background: rgba(0, 0, 0, 0.8);
+  border: 1px solid #38d431;
   border-radius: 10px;
 }
 
 .modal span {
   float: right;
   cursor: pointer;
+  color: #38d431;
 }
 
 .modal div {
   border-bottom: 1px solid #ccc;
   margin-left: 10px;
+  color: white;
 }
 
 .modal div:last-child {
@@ -24,4 +26,5 @@
   display: block;
   margin-top: 10px;
   margin-left: 10px;
+  color: #38d431;
 }

--- a/styles/displayComments.css
+++ b/styles/displayComments.css
@@ -1,0 +1,27 @@
+.modal {
+  position: absolute;
+  width: 300px;
+  background: white;
+  border: 1px solid black;
+  border-radius: 10px;
+}
+
+.modal span {
+  float: right;
+  cursor: pointer;
+}
+
+.modal div {
+  border-bottom: 1px solid #ccc;
+  margin-left: 10px;
+}
+
+.modal div:last-child {
+  border-bottom: none;
+}
+
+.modal a {
+  display: block;
+  margin-top: 10px;
+  margin-left: 10px;
+}

--- a/styles/displayComments.css
+++ b/styles/displayComments.css
@@ -1,17 +1,18 @@
 .icon {
-  border-radius: 50%;
+  position: absolute;
   width: 40px;
   height: 40px;
-  position: absolute;
+  border-radius: 50%;
 }
 
 .modal {
+  display: none;
   position: absolute;
   width: 300px;
   background: rgba(0, 0, 0, 0.8);
   border: 1px solid #38d431;
   border-radius: 10px;
-  display: none;
+  color: white;
 }
 
 .modal span {

--- a/vite.config.js
+++ b/vite.config.js
@@ -12,6 +12,7 @@ export default defineConfig({
         "./service_worker.js",
         "./addNewComment.js",
         "./displayComments.js",
+        "./styles/displayComments.css",
       ],
     }),
   ],


### PR DESCRIPTION
### itsComments

## 화면에 댓글표시 수정

## Todo

- [x] 칸반 외 작업

## Description

- 기존의 displayComments.js 파일에서 css 스타일을 적용하던 Inline CSS 방식에서 External styling 방식으로 변경
- 기존의 흰색배경에 회색글자색 its-comments 메인 색으로 변경
- 기존의 바로 댓글나오는 형태에서 페이지 이동시 아이콘으로 표시되게 변경
- 아이콘을 클릭시 댓글모달 표시

## Concern(필요시)

- 리뷰 요청 부분 & 컨펌 필요 부분

## PR 전 확인사항

- [x] 가장 최신 브랜치를 pull
- [x] 브랜치명 확인하기
- [x] 코드 컨벤션을 모두 지키기
- [x] reviewer, assignee 확인하기
- [x] conflict가 모두 해결됐는지 확인하기

### 이미지(필요시)
